### PR TITLE
Relaxed gem version restrictions

### DIFF
--- a/ruby_vcloud_sdk.gemspec
+++ b/ruby_vcloud_sdk.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |s|
   s.files        = `git ls-files -- lib/*`.split("\n") + %w(README.md)
   s.require_path = "lib"
 
-  s.add_dependency "builder", "~>3.1.4"
-  s.add_dependency "httpclient", "~>2.4.0"
-  s.add_dependency "rest-client", "~>1.6.7"
-  s.add_dependency "nokogiri", ">=1.5.6"
+  s.add_dependency "builder", ">= 3.1"
+  s.add_dependency "httpclient", ">= 2.4.0"
+  s.add_dependency "rest-client", ">= 1.6.7"
+  s.add_dependency "nokogiri", ">= 1.5.6"
   s.add_dependency "netaddr"
 end


### PR DESCRIPTION
To make this compatible with a repository using the latest Ruby on Rails version, I had to relax the gem version restrictions (many which have a newer minor version).  I reran the tests and they passed with these gem versions:

* builder 3.2.2
* httpclient 2.6.0.1
* rest-client 1.7.2